### PR TITLE
Docker entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,6 @@ services:
       MOD_PASSWORD: "${MOD_PASSWORD:-mod}"
       PAD_PASSWORD: "${PAD_PASSWORD:-pad}"
       DOCKER: 1
-    command: bash -c "DJANGO_MOCK=1 python manage.py migrate --noinput && scripts/create_users.sh && /usr/local/bin/daphne --bind 0.0.0.0 --port 9000 main.asgi:application"
     expose:
       - 9000
     volumes:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,15 @@
 FROM raveberry/raveberry-dependencies
 
-RUN pip install psycopg2 &&\
-	pip install -U youtube-dl &&\
+RUN pip install -U youtube-dl &&\
 	pip install raveberry --no-deps --target /opt &&\
 	rm -rf ~/.cache/pip
 
-COPY . /opt/raveberry/static
+EXPOSE 9000
+
+COPY docker/entrypoint.sh /entrypoint.sh
 
 WORKDIR /opt/raveberry
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["/usr/local/bin/daphne", "--bind", "0.0.0.0", "--port", "9000", "main.asgi:application"]

--- a/docker/dependencies.Dockerfile
+++ b/docker/dependencies.Dockerfile
@@ -2,7 +2,8 @@ FROM python:3
 
 COPY common.txt .
 RUN apt-get update &&\
-	apt-get install -y ffmpeg atomicparsley wget gnupg &&\
+	apt-get install -y ffmpeg atomicparsley wget gnupg audiotools &&\
 	apt-get clean &&\
 	pip install -r common.txt &&\
+	ln -s /usr/lib/python3/dist-packages/audiotools /usr/local/lib/python3.8/site-packages &&\
 	rm -rf ~/.cache/pip

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+DJANGO_MOCK=1 python manage.py migrate --noinput
+scripts/create_users.sh
+
+echo "Starting: ${@}"
+exec "${@}"

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -12,3 +12,5 @@ python-dateutil>=2.8.0
 requests>=2.22.0
 soundcloud>=0.5.0
 youtube-dl>=2019.8.2
+psycopg2
+https://github.com/DarwinAwardWinner/rganalysis/archive/master.zip


### PR DESCRIPTION
Instead of requiring calling the right commands when running the container, this has been moved to a docker entrypoint script. I also made sure the rganalysis tool and its dependency audiotools is installed so we can take advantage of that in docker as well!

I removed copying the static files since that was instead copying the entire root of raveberry in the static directory in the container. When the actual static directory was copied to the container, that made no difference to the files that were already there (I diffed the before and after contents of the directory).