### PR TITLE
made streaming password optional in icecast container

### DIFF
--- a/docker/icecast-entrypoint.sh
+++ b/docker/icecast-entrypoint.sh
@@ -2,11 +2,15 @@
 
 sed -i "s/<admin-password>[^<]*<\/admin-password>/<admin-password>$ICECAST_ADMIN_PASSWORD<\/admin-password>/g" /etc/icecast.xml
 
-USER=raveberry
-PASS="$STREAM_PASSWORD"
-HASH=$(echo -n $PASS | md5sum | awk '{ print $1 }')
-ENTRY="$USER:$HASH"
-echo "$ENTRY" > /usr/share/icecast/.htaccess
-chown icecast:icecast /usr/share/icecast/.htaccess
+if [ -z "${STREAM_NOAUTH}" ]; then
+	USER=${STREAM_USERNAME:=raveberry}
+	PASS=${STREAM_PASSWORD:=raveberry}
+	HASH=$(echo -n ${PASS} | md5sum | awk '{ print $1 }')
+	echo "${USER}:${HASH}" > /usr/share/icecast/.htaccess
+	chown icecast:icecast /usr/share/icecast/.htaccess
+
+	sed -i -e 's#<!-- <authentication#<authentication#' \
+		-e 's#</authentication> -->#</authentication>#' /etc/icecast.xml
+fi
 
 exec "$@"

--- a/docker/icecast.xml
+++ b/docker/icecast.xml
@@ -246,10 +246,10 @@
         <stream-description>Vote for the music you want to listen to!</stream-description>
         <fallback-mount>/silence.mp3</fallback-mount>
         <fallback-override>1</fallback-override>
-        <authentication type="htpasswd">
+        <!-- <authentication type="htpasswd">
             <option name="filename" value="/usr/share/icecast/.htaccess"/>
             <option name="allow_duplicate_users" value="1"/>
-        </authentication>
+        </authentication> -->
     </mount>
 
 </icecast>

--- a/icecast.docker-compose.yml
+++ b/icecast.docker-compose.yml
@@ -24,7 +24,10 @@ services:
     image: raveberry/raveberry-icecast
     environment:
       ICECAST_ADMIN_PASSWORD: "${ICECAST_ADMIN_PASSWORD:-hackme}"
+      STREAM_USERNAME: "${STREAM_USERNAME:-raveberry}"
       STREAM_PASSWORD: "${STREAM_PASSWORD:-raveberry}"
+      # or set STREAM_NOAUTH if you don't want to protect your stream
+      # STREAM_NOAUTH: 1
     # uncomment this port mapping if you need to access icecast's web interface
     #ports:
     #  - 8000:8000


### PR DESCRIPTION
This PR allows you to easily disable using a streaming password and simplifies the entrypoint script for icecast a bit. It also allows to override the default streaming username to something else than `raveberry`