### PR TITLE
allow to specify spotify and soundcloud credentials for mopidy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,13 @@ services:
   mopidy:
     image: raveberry/raveberry-mopidy
     user: "${UID:-1000}:${GID:-1000}"
+    environment:
+      # optional spotify and soundcloud settings
+      # - SPOTIFY_USERNAME=raveberry
+      # - SPOTIFY_PASSWORD=s3cr3t
+      # - SPOTIFY_CLIENT_ID=raveberry
+      # - SPOTIFY_CLIENT_SECRET=s3cret
+      # - SOUNDCLOUD_AUTH_TOKEN=s3cret
     volumes:
       - songs-cache:/Music/raveberry
       # Comment this line if pulse does not work.

--- a/docker/mopidy-entrypoint.sh
+++ b/docker/mopidy-entrypoint.sh
@@ -5,4 +5,11 @@ if [ -z "$PULSE_COOKIE_DATA" ]; then
     export PULSE_COOKIE=$HOME/pulse.cookie
 fi
 
+# substitute potentially set environment variables
+for KEY in SPOTIFY_USERNAME SPOTIFY_PASSWORD SPOTIFY_CLIENT_ID SPOTIFY_CLIENT_SECRET SOUNDCLOUD_AUTH_TOKEN; do
+    [ -z "$(printenv ${KEY})" ] && continue
+    SHORT=$(echo ${KEY#*_} | tr A-Z a-z)
+    sed -i "s/^.* # ${KEY}/${SHORT} = $(printenv ${KEY})/" /config/mopidy.conf /config/mopidy_icecast.conf
+done
+
 exec "$@"

--- a/docker/mopidy.Dockerfile
+++ b/docker/mopidy.Dockerfile
@@ -21,7 +21,7 @@ COPY pulse-client.conf /etc/pulse/client.conf
 ENV HOME=/var/lib/mopidy
 RUN set -ex \
  && usermod -G audio,sudo mopidy \
- && chown mopidy:audio -R $HOME /entrypoint.sh \
+ && chown mopidy:audio -R $HOME /entrypoint.sh /config \
  && chmod go+rwx -R $HOME /entrypoint.sh
 
 # Runs as mopidy user by default.

--- a/docker/mopidy.conf
+++ b/docker/mopidy.conf
@@ -5,10 +5,10 @@ output = rgvolume ! audioconvert ! audioresample ! autoaudiosink
 hostname = 0.0.0.0
 
 [spotify]
-username =
-password =
-client_id =
-client_secret =
+username = # SPOTIFY_USERNAME
+password = # SPOTIFY_PASSWORD
+client_id = # SPOTIFY_CLIENT_ID
+client_secret = # SPOTIFY_CLIENT_SECRET
 search_album_count = 1
 search_artist_count = 1
 search_track_count = 1
@@ -17,4 +17,4 @@ allow_playlists = false
 private_session = true
 
 [soundcloud]
-auth_token =
+auth_token = # SOUNDCLOUD_AUTH_TOKEN

--- a/docker/mopidy_icecast.conf
+++ b/docker/mopidy_icecast.conf
@@ -5,10 +5,10 @@ output = rgvolume ! audioconvert ! audioresample ! lamemp3enc ! shout2send ip=ic
 hostname = 0.0.0.0
 
 [spotify]
-username =
-password =
-client_id =
-client_secret =
+username = # SPOTIFY_USERNAME
+password = # SPOTIFY_PASSWORD
+client_id = # SPOTIFY_CLIENT_ID
+client_secret = # SPOTIFY_CLIENT_SECRET
 search_album_count = 1
 search_artist_count = 1
 search_track_count = 1
@@ -17,4 +17,4 @@ allow_playlists = false
 private_session = true
 
 [soundcloud]
-auth_token =
+auth_token = # SOUNDCLOUD_AUTH_TOKEN


### PR DESCRIPTION
during startup of mopidy, credentials passed by environment variables will be replaced in `mopidy.conf`, where I added some placeholders so `sed` can properly replace the right variables.