### PR TITLE
add optional filter to spotify results

### DIFF
--- a/core/settings/platforms.py
+++ b/core/settings/platforms.py
@@ -28,6 +28,7 @@ class Platforms:
             Settings.get_setting("spotify_enabled", "False") == "True"
         )
         self.spotify_suggestions = int(Settings.get_setting("spotify_suggestions", "2"))
+        self.spotify_filter = Settings.get_setting("spotify_filter", "")
         self.spotify_username = Settings.get_setting("spotify_username", "")
         self.spotify_password = Settings.get_setting("spotify_password", "")
         self.spotify_client_id = Settings.get_setting("spotify_client_id", "")
@@ -86,6 +87,13 @@ class Platforms:
         value = int(request.POST.get("value"))  # type: ignore
         Setting.objects.filter(key="spotify_suggestions").update(value=value)
         self.spotify_suggestions = value
+
+    @Settings.option
+    def set_spotify_filter(self, request: WSGIRequest):
+        """Sets the keywords to filter out of results."""
+        value = request.POST.get("value")
+        Setting.objects.filter(key="spotify_filter").update(value=value)
+        self.spotify_filter = value
 
     @Settings.option
     def set_spotify_credentials(self, request: WSGIRequest) -> HttpResponse:

--- a/core/settings/settings.py
+++ b/core/settings/settings.py
@@ -103,6 +103,7 @@ class Settings(Stateful):
 
         state_dict["spotify_enabled"] = self.platforms.spotify_enabled
         state_dict["spotify_suggestions"] = self.platforms.spotify_suggestions
+        state_dict["spotify_filter"] = self.platforms.spotify_filter
 
         state_dict["soundcloud_enabled"] = self.platforms.soundcloud_enabled
         state_dict["soundcloud_suggestions"] = self.platforms.soundcloud_suggestions

--- a/core/urls.py
+++ b/core/urls.py
@@ -154,6 +154,11 @@ SETTINGS_URLS = [
         name="set_spotify_suggestions",
     ),
     path(
+        "set_spotify_filter/",
+        BASE.settings.platforms.set_spotify_filter,
+        name="set_spotify_filter",
+    ),
+    path(
         "set_spotify_credentials/",
         BASE.settings.platforms.set_spotify_credentials,
         name="set_spotify_credentials",

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -21,6 +21,7 @@ specificState = function (newState) {
 
 	$('#spotify_enabled').prop("checked", newState.spotify_enabled);
 	$('#spotify_suggestions').val(newState.spotify_suggestions);
+	$('#spotify_filter').val(newState.spotify_filter);
 
 	$('#soundcloud_enabled').prop("checked", newState.soundcloud_enabled);
 	$('#soundcloud_suggestions').val(newState.soundcloud_suggestions);
@@ -171,6 +172,13 @@ $(document).ready(function() {
 		$.post(urls['set_spotify_suggestions'], {
 			value: $(this).val(),
 		}).done(function(response) {
+			successToast(response);
+		});
+	});
+	$('#spotify_filter').change(function () {
+		$.post(urls['set_spotify_filter'], {
+			value: $(this).val(),
+		}).done(function (response) {
 			successToast(response);
 		});
 	});

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -132,7 +132,7 @@
         Youtube
     </li>
     <li class="list-group-item list_item">
-        <span class="description">enabled</span>
+        <span class="description">Enabled</span>
         <input type="checkbox" id="youtube_enabled">
     </li>
     <li class="list-group-item list_item">
@@ -146,7 +146,7 @@
 		Spotify
 	</li>
 	<li class="list-group-item list_item">
-        <span class="description">enabled</span>
+        <span class="description">Enabled</span>
         <input type="checkbox" id="spotify_enabled">
 	</li>
     <li class="list-group-item list_item">
@@ -189,7 +189,7 @@
         Soundcloud
     </li>
     <li class="list-group-item list_item">
-        <span class="description">enabled</span>
+        <span class="description">Enabled</span>
         <input type="checkbox" id="soundcloud_enabled">
     </li>
     <li class="list-group-item list_item">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -22,6 +22,7 @@
     urls['set_spotify_enabled'] = '{% url 'set_spotify_enabled' %}';
 	urls['set_spotify_credentials'] = '{% url 'set_spotify_credentials' %}';
     urls['set_spotify_suggestions'] = '{% url 'set_spotify_suggestions' %}';
+	urls['set_spotify_filter'] = '{% url 'set_spotify_filter' %}';
 
     urls['set_soundcloud_enabled'] = '{% url 'set_soundcloud_enabled' %}';
     urls['set_soundcloud_credentials'] = '{% url 'set_soundcloud_credentials' %}';
@@ -152,6 +153,10 @@
         <span class="description">Number of online suggestions</span>
         <input id="spotify_suggestions"/>
     </li>
+	<li class="list-group-item list_item">
+		<span class="description">Keywords to filter out of results</span>
+		<input id="spotify_filter"/>
+	</li>
 	<li class="list-group-item list_item">
 		<span class="description">Username</span>
 		<input id="spotify_username"/>


### PR DESCRIPTION
Allow to specify a list of keywords to filter out results from spotify.

This partially solves https://github.com/raveberry/raveberry/issues/71.